### PR TITLE
Add local CrewAI FastMCP integration with Gemini

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,9 @@ yarn-debug.log*
 yarn-error.log*
 .pnpm-debug.log*
 
+# Python
+__pycache__/
+
 # env files (can opt-in for committing if needed)
 .env*
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This is a starter template for building AI agents using [CrewAI Flows](https://d
   - npm
   - [yarn](https://classic.yarnpkg.com/lang/en/docs/install/#mac-stable)
   - [bun](https://bun.sh/)
-- OpenAI API Key (for the CrewAI Flow agent)
+- Google Gemini API Key (for the CrewAI Flow agent)
 
 > **Note:** This repository ignores lock files (package-lock.json, yarn.lock, pnpm-lock.yaml, bun.lockb) to avoid conflicts between different package managers. Each developer should generate their own lock file using their preferred package manager. After that, make sure to delete it from the .gitignore.
 
@@ -35,10 +35,10 @@ bun install
 > **Note:** Installing the package dependencies will also install the agent's python dependencies via the `install:agent` script.
 
 
-2. Set up your OpenAI API key:
+2. Set up your Gemini API key:
 ```bash
-cd agent
-echo "OPENAI_API_KEY=your-openai-api-key-here" > .env
+cd backend
+echo "GEMINI_API_KEY=your-gemini-api-key-here" > .env
 ```
 
 3. Start the development server:
@@ -56,7 +56,8 @@ yarn dev
 bun run dev
 ```
 
-This will start both the UI and agent servers concurrently.
+This will start both the UI and agent servers concurrently. The backend uses
+Gemini via LiteLLM and exposes a FastMCP server on port 8000.
 
 ## Available Scripts
 The following scripts can also be run using your preferred package manager:
@@ -96,5 +97,5 @@ This project is licensed under the MIT License - see the LICENSE file for detail
 ### Agent Connection Issues
 If you see "I'm having trouble connecting to my tools", make sure:
 1. The CrewAI Flow agent is running on port 8000
-2. Your OpenAI API key is set correctly
+2. Your Gemini API key is set correctly
 3. Both servers started successfully

--- a/backend/flow.py
+++ b/backend/flow.py
@@ -1,0 +1,33 @@
+from crewai import Agent, Task, Flow, LLM
+from crewai_tools import FileReadTool
+import os
+
+# Initialize Gemini LLM via LiteLLM
+llm = LLM(
+    model="gemini/gemini-2.0-flash",
+    api_key=os.getenv("GEMINI_API_KEY"),
+    max_rpm=10
+)
+
+# Built-in FileReadTool (additional tools can be added to this list)
+file_tool = FileReadTool()
+
+agent = Agent(
+    role="Assistant",
+    goal="Answer queries; read files when needed.",
+    backstory="A single-agent Crew with file-reading skills.",
+    llm=llm,
+    tools=[file_tool],
+    reasoning=True,
+    max_reasoning_attempts=3
+)
+
+task = Task(
+    description="Respond to the user's query using tools if required.",
+    expected_output="Final answer to the user",
+    agent=agent,
+    markdown=True
+)
+
+# Flow with single agent and task
+flow = Flow(agents=[agent], tasks=[task])

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,6 @@
+crewai==0.130.0
+crewai-tools>=0.9.0
+litellm>=1.39.0
+fastmcp>=2.0.0
+uvicorn>=0.34.0
+python-dotenv>=1.0.1

--- a/backend/server.py
+++ b/backend/server.py
@@ -1,0 +1,19 @@
+import os
+from dotenv import load_dotenv
+from fastmcp import FastMCP
+from .flow import agent, task
+from crewai import Crew
+
+load_dotenv()
+
+mcp = FastMCP("local-crewai")
+
+@mcp.tool()
+async def run_agent(query: str) -> str:
+    """Run the CrewAI flow to answer the query."""
+    task.description = f'User asks: "{query}"'
+    crew = Crew(agents=[agent], tasks=[task])
+    return crew.kickoff()
+
+if __name__ == "__main__":
+    mcp.serve(host="0.0.0.0", port=8000, transport="streamable-http")

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
     "postinstall": "npm run install:agent"
   },
   "dependencies": {
-    "@ag-ui/crewai": "^0.0.2",
     "@copilotkit/react-core": "1.9.3",
     "@copilotkit/react-ui": "1.9.3",
     "@copilotkit/runtime": "1.9.3",

--- a/scripts/run-agent.bat
+++ b/scripts/run-agent.bat
@@ -1,9 +1,9 @@
 @echo off
-REM Navigate to the agent directory
-cd /d %~dp0\..\agent
+REM Navigate to the backend directory
+cd /d %~dp0\..\backend
 
 REM Activate the virtual environment
 call .venv\Scripts\activate.bat
 
-REM Run the agent
-.venv\Scripts\python.exe server.py 
+REM Run the backend server
+.venv\Scripts\python.exe server.py

--- a/scripts/run-agent.sh
+++ b/scripts/run-agent.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
-# Navigate to the agent directory
-cd "$(dirname "$0")/../agent" || exit 1
+# Navigate to the backend directory
+cd "$(dirname "$0")/../backend" || exit 1
 
 # Activate the virtual environment
 source .venv/bin/activate
 
-# Run the agent
+# Run the backend server
 .venv/bin/python server.py

--- a/scripts/setup-agent.bat
+++ b/scripts/setup-agent.bat
@@ -1,6 +1,6 @@
 @echo off
-REM Navigate to the agent directory
-cd /d "%~dp0\..\agent" || exit /b 1
+REM Navigate to the backend directory
+cd /d "%~dp0\..\backend" || exit /b 1
 
 REM Create virtual environment if it doesn't exist
 if not exist ".venv" (
@@ -11,4 +11,4 @@ REM Activate the virtual environment
 call .venv\Scripts\activate.bat
 
 REM Install requirements using pip
-pip install -r requirements.txt 
+pip install -r requirements.txt

--- a/scripts/setup-agent.sh
+++ b/scripts/setup-agent.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-# Navigate to the agent directory
-cd "$(dirname "$0")/../agent" || exit 1
+# Navigate to the backend directory
+cd "$(dirname "$0")/../backend" || exit 1
 
 # Create virtual environment if it doesn't exist
 if [ ! -d ".venv" ]; then

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -17,7 +17,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className={"antialiased"}>
-        <CopilotKit runtimeUrl="/api/copilotkit" agent="starterAgent">
+        <CopilotKit runtimeUrl="http://localhost:8000" agent="starterAgent" transport="streamable-http">
           {children}
         </CopilotKit>
       </body>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,11 +1,16 @@
 "use client";
 
-import { useCoAgent, useCopilotAction } from "@copilotkit/react-core";
+import { useCoAgent, useCopilotAction, useCoAgentStateRender } from "@copilotkit/react-core";
 import { CopilotKitCSSProperties, CopilotSidebar } from "@copilotkit/react-ui";
 import { useState } from "react";
 
 export default function CopilotKitPage() {
   const [themeColor, setThemeColor] = useState("#6366f1");
+
+  useCoAgentStateRender({
+    name: "starterAgent",
+    render: ({ state }) => <AgentTimeline items={state.timeline} />,
+  });
 
   // 🪁 Frontend Actions: https://docs.copilotkit.ai/guides/frontend-actions
   useCopilotAction({
@@ -167,5 +172,41 @@ function WeatherCard({ location, themeColor }: { location?: string, themeColor: 
       </div>
     </div>
   </div>
+  );
+}
+
+type TimelineItem = {
+  name?: string;
+  description?: string;
+  thought?: string;
+  tool?: string;
+  result?: unknown;
+};
+
+function AgentTimeline({ items }: { items?: TimelineItem[] }) {
+  if (!items) return null;
+  return (
+    <div className="space-y-2">
+      {items.map((item, idx) => (
+        <div key={idx} className="bg-white/10 p-2 rounded-md text-white">
+          <div className="font-semibold">
+            {item.tool ? `Used ${item.tool}` : item.name}
+          </div>
+          {item.description && <div className="text-sm">{item.description}</div>}
+          {item.thought && (
+            <details className="text-sm">
+              <summary>Thought</summary>
+              <pre className="whitespace-pre-wrap">{item.thought}</pre>
+            </details>
+          )}
+          {item.result && (
+            <details className="text-sm">
+              <summary>Result</summary>
+              <pre className="whitespace-pre-wrap">{JSON.stringify(item.result, null, 2)}</pre>
+            </details>
+          )}
+        </div>
+      ))}
+    </div>
   );
 }

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -1,0 +1,18 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from backend.flow import agent, task
+from crewai import Crew
+
+
+def test_file_read_tool(tmp_path):
+    sample = Path('sample.txt')
+    sample.write_text('Revenue was $1000 in Q4.')
+    try:
+        query = f"Read the file {sample} and repeat its contents."
+        task.description = f'User asks: "{query}"'
+        result = Crew(agents=[agent], tasks=[task]).kickoff()
+        assert 'Revenue was $1000 in Q4.' in result.raw
+    finally:
+        sample.unlink()


### PR DESCRIPTION
## Summary
- wire up a Gemini-powered CrewAI agent with FileReadTool and reasoning
- expose the agent through a FastMCP `streamable-http` server
- connect Next.js CopilotKit frontend to the MCP server and render tool usage timeline

## Testing
- `pytest tests/test_backend.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688fdd98f9a88321822ca051c2065954