### PR TITLE
Simplify demo to focus on file reading and proverbs

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,10 +72,9 @@ The following scripts can also be run using your preferred package manager:
 ## Documentation
 
 The main UI component is in `src/app/page.tsx`. You can:
-- Modify the theme colors and styling
 - Add new frontend actions
 - Utilize shared-state
-- Customize your user-interface for interactin with CrewAI Flow
+- Customize your user-interface for interacting with CrewAI Flow
 
 ## 📚 Documentation
 

--- a/agent/copilot_bridge_tool.py
+++ b/agent/copilot_bridge_tool.py
@@ -84,17 +84,6 @@ class CopilotBridgeTool(BaseTool):
                     except Exception as e:  # pragma: no cover
                         result_msg = f"Failed to add proverb: {e}"
             
-            # Handle setting theme color - match frontend parameter names
-            elif self.name.lower() in {"setthemecolor", "set_theme_color", "settheme", "set_theme"}:
-                # Try multiple possible parameter names to match frontend
-                theme = (kwargs.get("themeColor") or kwargs.get("theme_color") or 
-                        kwargs.get("theme") or kwargs.get("color") or kwargs.get("value"))
-                if theme:
-                    try:
-                        flow.state.theme = str(theme)  # type: ignore[attr-defined]
-                        result_msg = f"🎨 Theme changed to {theme}"
-                    except Exception as e:  # pragma: no cover
-                        result_msg = f"Failed to set theme: {e}"
         
         # Send events to CopilotKit frontend
         if queue is not None:

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,23 +2,9 @@
 
 import { useCoAgent, useCopilotAction } from "@copilotkit/react-core";
 import { CopilotKitCSSProperties, CopilotSidebar } from "@copilotkit/react-ui";
-import { useState } from "react";
 
 export default function CopilotKitPage() {
-  const [themeColor, setThemeColor] = useState("#6366f1");
-
-  // 🪁 Frontend Actions: https://docs.copilotkit.ai/guides/frontend-actions
-  useCopilotAction({
-    name: "setThemeColor",
-    parameters: [{
-      name: "themeColor",
-      description: "The theme color to set. Make sure to pick nice colors.",
-      required: true, 
-    }],
-    handler({ themeColor }) {
-      setThemeColor(themeColor);
-    },
-  });
+  const themeColor = "#6366f1";
 
   return (
     <main style={{ "--copilot-kit-primary-color": themeColor } as CopilotKitCSSProperties}>
@@ -28,7 +14,8 @@ export default function CopilotKitPage() {
         defaultOpen={true}
         labels={{
           title: "Popup Assistant",
-          initial: "👋 Hi, there! You're chatting with an agent. This agent comes with a few tools to get you started.\n\nFor example you can try:\n- **Frontend Tools**: \"Set the theme to orange\"\n- **Shared State**: \"Write a proverb about AI\"\n- **Generative UI**: \"Get the weather in SF\"\n\nAs you interact with the agent, you'll see the UI update in real-time to reflect the agent's **state**, **tool calls**, and **progress**."
+          initial:
+            "👋 Hi, there! You're chatting with an agent. This agent comes with a few tools to get you started.\n\nFor example you can try:\n- **File Tools**: \"Read the README file\"\n- **Shared State**: \"Write a proverb about AI\"\n\nAs you interact with the agent, you'll see the UI update in real-time to reflect the agent's **state**, **tool calls**, and **progress**.",
         }}
       />
     </main>
@@ -38,45 +25,34 @@ export default function CopilotKitPage() {
 // State of the agent, make sure this aligns with your agent's state.
 type AgentState = {
   proverbs: string[];
-}
+};
 
 function YourMainContent({ themeColor }: { themeColor: string }) {
   // 🪁 Shared State: https://docs.copilotkit.ai/coagents/shared-state
-  const {state, setState} = useCoAgent<AgentState>({
+  const { state, setState } = useCoAgent<AgentState>({
     name: "starterAgent",
     initialState: {
       proverbs: [
         "CopilotKit may be new, but its the best thing since sliced bread.",
       ],
     },
-  })
+  });
 
   // 🪁 Frontend Actions: https://docs.copilotkit.ai/coagents/frontend-actions
   useCopilotAction({
     name: "addProverb",
-    parameters: [{
-      name: "proverb",
-      description: "The proverb to add. Make it witty, short and concise.",
-      required: true,
-    }],
+    parameters: [
+      {
+        name: "proverb",
+        description: "The proverb to add. Make it witty, short and concise.",
+        required: true,
+      },
+    ],
     handler: ({ proverb }) => {
       setState({
         ...state,
         proverbs: [...state.proverbs, proverb],
       });
-    },
-  });
-
-  //🪁 Generative UI: https://docs.copilotkit.ai/coagents/generative-ui
-  useCopilotAction({
-    name: "get_weather",
-    description: "Get the weather for a given location.",
-    available: "disabled",
-    parameters: [
-      { name: "location", type: "string", required: true },
-    ],
-    render: ({ args }) => {
-      return <WeatherCard location={args.location} themeColor={themeColor} />
     },
   });
 
@@ -87,21 +63,25 @@ function YourMainContent({ themeColor }: { themeColor: string }) {
     >
       <div className="bg-white/20 backdrop-blur-md p-8 rounded-2xl shadow-xl max-w-2xl w-full">
         <h1 className="text-4xl font-bold text-white mb-2 text-center">Proverbs</h1>
-        <p className="text-gray-200 text-center italic mb-6">This is a demonstrative page, but it could be anything you want! 🪁</p>
+        <p className="text-gray-200 text-center italic mb-6">
+          This is a demonstrative page, but it could be anything you want! 🪁
+        </p>
         <hr className="border-white/20 my-6" />
         <div className="flex flex-col gap-3">
           {state.proverbs?.map((proverb, index) => (
-            <div 
-              key={index} 
+            <div
+              key={index}
               className="bg-white/15 p-4 rounded-xl text-white relative group hover:bg-white/20 transition-all"
             >
               <p className="pr-8">{proverb}</p>
-              <button 
-                onClick={() => setState({
-                  ...state,
-                  proverbs: state.proverbs?.filter((_, i) => i !== index),
-                })}
-                className="absolute right-3 top-3 opacity-0 group-hover:opacity-100 transition-opacity 
+              <button
+                onClick={() =>
+                  setState({
+                    ...state,
+                    proverbs: state.proverbs?.filter((_, i) => i !== index),
+                  })
+                }
+                className="absolute right-3 top-3 opacity-0 group-hover:opacity-100 transition-opacity
                   bg-red-500 hover:bg-red-600 text-white rounded-full h-6 w-6 flex items-center justify-center"
               >
                 ✕
@@ -109,63 +89,13 @@ function YourMainContent({ themeColor }: { themeColor: string }) {
             </div>
           ))}
         </div>
-        {state.proverbs?.length === 0 && <p className="text-center text-white/80 italic my-8">
-          No proverbs yet. Ask the assistant to add some!
-        </p>}
+        {state.proverbs?.length === 0 && (
+          <p className="text-center text-white/80 italic my-8">
+            No proverbs yet. Ask the assistant to add some!
+          </p>
+        )}
       </div>
     </div>
   );
 }
 
-// Simple sun icon for the weather card
-function SunIcon() {
-  return (
-    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" className="w-14 h-14 text-yellow-200">
-      <circle cx="12" cy="12" r="5" />
-      <path d="M12 1v2M12 21v2M4.22 4.22l1.42 1.42M18.36 18.36l1.42 1.42M1 12h2M21 12h2M4.22 19.78l1.42-1.42M18.36 5.64l1.42-1.42" strokeWidth="2" stroke="currentColor" />
-    </svg>
-  );
-}
-
-// Weather card component where the location and themeColor are based on what the agent
-// sets via tool calls.
-function WeatherCard({ location, themeColor }: { location?: string, themeColor: string }) {
-  return (
-    <div
-    style={{ backgroundColor: themeColor }}
-    className="rounded-xl shadow-xl mt-6 mb-4 max-w-md w-full"
-  >
-    <div className="bg-white/20 p-4 w-full">
-      <div className="flex items-center justify-between">
-        <div>
-          <h3 className="text-xl font-bold text-white capitalize">{location}</h3>
-          <p className="text-white">Current Weather</p>
-        </div>
-        <SunIcon />
-      </div>
-      
-      <div className="mt-4 flex items-end justify-between">
-        <div className="text-3xl font-bold text-white">70°</div>
-        <div className="text-sm text-white">Clear skies</div>
-      </div>
-      
-      <div className="mt-4 pt-4 border-t border-white">
-        <div className="grid grid-cols-3 gap-2 text-center">
-          <div>
-            <p className="text-white text-xs">Humidity</p>
-            <p className="text-white font-medium">45%</p>
-          </div>
-          <div>
-            <p className="text-white text-xs">Wind</p>
-            <p className="text-white font-medium">5 mph</p>
-          </div>
-          <div>
-            <p className="text-white text-xs">Feels Like</p>
-            <p className="text-white font-medium">72°</p>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-  );
-}


### PR DESCRIPTION
## Summary
- remove theme-changing and weather demo code
- keep only file reading and proverb UI actions

## Testing
- `python -m py_compile agent/agent.py agent/copilot_bridge_tool.py`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689035f7a74c83218abc3c76f33359c3